### PR TITLE
allow `-` in package name

### DIFF
--- a/source/commands/main.d
+++ b/source/commands/main.d
@@ -365,7 +365,7 @@ string loadCurrentProjectName()
     {
         import std.regex : ctRegex, matchFirst;
 
-        enum pattern = ctRegex!"^name \"(\\w+)\"$";
+        enum pattern = ctRegex!`^name "([-\w]+)"$`;
         auto f = File("dub.sdl", "r");
         foreach (line; f.byLine())
         {


### PR DESCRIPTION
Fixes reading from local package if it contains a hyphen