### PR TITLE
Add build-only option for markdown block evaluation

### DIFF
--- a/source/commands/main.d
+++ b/source/commands/main.d
@@ -51,7 +51,7 @@ struct DefaultCommand
         @(ArgConfig.aggregate | ArgConfig.optional)
         string[] filters;
 
-        @ArgNamed("buildOnly|no-run|dry-build", "Build the code without running it")
+        @ArgNamed("buildOnly|no-run", "Build the code without running it")
         @(ArgConfig.parseAsFlag)
         bool buildOnly;
     }

--- a/source/commands/main.d
+++ b/source/commands/main.d
@@ -50,6 +50,10 @@ struct DefaultCommand
         @ArgNamed("filter", "Filter blocks by name")
         @(ArgConfig.aggregate | ArgConfig.optional)
         string[] filters;
+
+        @ArgNamed("buildOnly|no-run|dry-build", "Build the code without running it")
+        @(ArgConfig.parseAsFlag)
+        bool buildOnly;
     }
 
     int onExecute()
@@ -132,7 +136,7 @@ struct DefaultCommand
                 if (!quiet)
                     writeln("end: ", key);
 
-            const status = evaluate(value.data, dubInstructions, BlockType.Single, runSettings, verbose);
+            const status = evaluate(value.data, dubInstructions, BlockType.Single, runSettings, verbose, buildOnly);
             errorCount += status != 0;
         }
 
@@ -145,7 +149,7 @@ struct DefaultCommand
                 if (!quiet)
                     writeln("end single: ", i);
 
-            const status = evaluate(source, dubInstructions, BlockType.Single, runSettings, verbose);
+            const status = evaluate(source, dubInstructions, BlockType.Single, runSettings, verbose, buildOnly);
             errorCount += status != 0;
         }
 
@@ -158,7 +162,7 @@ struct DefaultCommand
                 if (!quiet)
                     writeln("end global :", i);
 
-            const status = evaluate(source, dubInstructions, BlockType.Global, runSettings, verbose);
+            const status = evaluate(source, dubInstructions, BlockType.Global, runSettings, verbose, buildOnly);
             errorCount += status != 0;
         }
 
@@ -377,7 +381,7 @@ struct DubRunSettings
     }
 }
 
-int evaluate(string source, string[] dubInstructions, BlockType type, DubRunSettings settings, bool verbose)
+int evaluate(string source, string[] dubInstructions, BlockType type, DubRunSettings settings, bool verbose, bool skipRun)
 {
     import std.conv : text, to;
     import std.digest : toHexString, LetterCase;
@@ -424,7 +428,7 @@ int evaluate(string source, string[] dubInstructions, BlockType type, DubRunSett
         sourceFile.flush();
     }
 
-    string[] args = ["dub", "run", "--single"];
+    string[] args = ["dub", skipRun ? "build" : "run", "--single"];
     if (!verbose)
         args ~= "--quiet";
 


### PR DESCRIPTION
## Summary
- add a buildOnly/no-run/dry-build flag to the default command to support building without running
- pass the skip-run flag through evaluation to switch between `dub run --single` and `dub build --single` while keeping existing arguments
- maintain existing logging/exit behaviors when evaluating blocks

closes #11

## Testing
- `dub test` *(fails: dub command not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941691482ac832c8300479708500423)