### PR TITLE
Support multiple names

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -108,6 +108,33 @@ auto message2 = "another filter test";
 writeln(message2);
 ```
 
+#### 複数の名前指定
+
+1つのコードブロックに対して、複数の `name` 属性を指定できます。
+このブロックは、指定したすべての名前のブロックに取り込まれます。
+
+~~~
+```d name=multi_name_test1 name=multi_name_test2
+```
+~~~
+
+```
+dub run md -- README.md --filter=multi_name_test1
+dub run md -- README.md --filter=multi_name_test2
+```
+
+```d name=multi_name_test1 name=multi_name_test2
+import std.stdio;
+```
+
+```d name=multi_name_test1
+writeln("multi-name test1");
+```
+
+```d name=multi_name_test2
+writeln("multi-name test2");
+```
+
 ### 独立実行
 
 1つのコードブロックを他のブロックと結合せず、独立して実行させるためには `single` という属性を付与します。

--- a/README.md
+++ b/README.md
@@ -106,6 +106,33 @@ auto message2 = "another filter test";
 writeln(message2);
 ```
 
+#### Multiple names
+
+You can assign multiple `name` attributes to a single code block.
+That block will be included in every matching named block.
+
+~~~
+```d name=multi_name_test1 name=multi_name_test2
+```
+~~~
+
+```
+dub run md -- README.md --filter=multi_name_test1
+dub run md -- README.md --filter=multi_name_test2
+```
+
+```d name=multi_name_test1 name=multi_name_test2
+import std.stdio;
+```
+
+```d name=multi_name_test1
+writeln("multi-name test1");
+```
+
+```d name=multi_name_test2
+writeln("multi-name test2");
+```
+
 
 
 ### Scoped block

--- a/examples/test-multiple-name.md
+++ b/examples/test-multiple-name.md
@@ -1,0 +1,48 @@
+__command__
+
+```
+dub run -- examples/test-multiple-name.md
+dub run -- examples/test-multiple-name.md --filter=test1
+dub run -- examples/test-multiple-name.md --filter=test2
+```
+
+__test code__
+
+```d name=test1 name=test2
+import std.stdio;
+```
+
+```d name=test1
+writeln("test1");
+```
+
+```d name=test2
+writeln("test2");
+```
+
+###  expected output
+
+no filter:
+
+__test1__
+```
+test1
+```
+__test2__
+```
+test2
+```
+
+filter test1:
+
+__test1__
+```
+test1
+```
+
+filter test2:
+
+__test2__
+```
+test2
+```

--- a/source/commands/main.d
+++ b/source/commands/main.d
@@ -91,6 +91,7 @@ struct DefaultCommand
         auto result = parseMarkdown(filepath);
 
         Appender!(string)[string] blocks;
+        string[] orderedNames;
         string[] singleBlocks;
         string[] globalBlocks;
         foreach (block; result.blocks)
@@ -99,9 +100,6 @@ struct DefaultCommand
             {
                 if (isDisabledBlock(block))
                     continue;
-                if (filters.length > 0 && !isFilteredBlock(block, filters))
-                    continue;
-
                 if (isSingleBlock(block))
                 {
                     singleBlocks ~= block.code[].to!string();
@@ -113,12 +111,23 @@ struct DefaultCommand
                     continue;
                 }
 
-                auto name = getBlockName(block);
-                if (!(name in blocks))
+                auto names = getBlockNames(block);
+                if (filters.length > 0)
                 {
-                    blocks[name] = appender!string;
+                    names = filterBlockNames(names, filters);
+                    if (names.length == 0)
+                        continue;
                 }
-                blocks[name].put(block.code[]);
+
+                foreach (name; names)
+                {
+                    if (!(name in blocks))
+                    {
+                        blocks[name] = appender!string;
+                        orderedNames ~= name;
+                    }
+                    blocks[name].put(block.code[]);
+                }
             }
         }
 
@@ -127,16 +136,16 @@ struct DefaultCommand
 
         size_t totalCount;
         size_t errorCount;
-        foreach (key, value; blocks)
+        foreach (name; orderedNames)
         {
             totalCount++;
             if (!quiet)
-                writeln("begin: ", key);
+                writeln("begin: ", name);
             scope (exit)
                 if (!quiet)
-                    writeln("end: ", key);
+                    writeln("end: ", name);
 
-            const status = evaluate(value.data, dubInstructions, BlockType.Single, runSettings, verbose, buildOnly);
+            const status = evaluate(blocks[name].data, dubInstructions, BlockType.Single, runSettings, verbose, buildOnly);
             errorCount += status != 0;
         }
 
@@ -321,30 +330,90 @@ bool isGlobalBlock(const ref Code code)
 
 bool isFilteredBlock(const ref Code code, string[] filters)
 {
-    auto blockName = getBlockName(code);
+    return filterBlockNames(getBlockNames(code), filters).length > 0;
+}
 
-    foreach (filterName; filters)
+string[] getBlockNames(const ref Code code)
+{
+    import std.regex : regex, matchAll;
+
+    auto pat = regex(`(?<=^|\s)name=(\w+)(?=\s|$)`);
+    bool[string] seen;
+    string[] names;
+
+    foreach (m; matchAll(code.info, pat))
     {
-        if (blockName == filterName)
+        if (m[1].length != 0)
         {
-            return true;
+            auto name = m[1].idup;
+            if (name in seen)
+                continue;
+
+            seen[name] = true;
+            names ~= name;
         }
     }
 
-    return false;
+    if (names.length == 0)
+        names ~= "main";
+
+    return names;
 }
 
-string getBlockName(const ref Code code)
+string[] filterBlockNames(string[] blockNames, string[] filters)
 {
-    import std.regex : regex, matchFirst;
-
-    auto pat = regex(`(?<=^|\s)name=(\w+)(?=\s|$)`);
-    if (auto m = matchFirst(code.info, pat))
+    string[] result;
+    foreach (name; blockNames)
     {
-        if (m[1].length != 0)
-            return m[1].idup;
+        foreach (filterName; filters)
+        {
+            if (name == filterName)
+            {
+                result ~= name;
+                break;
+            }
+        }
     }
-    return "main";
+
+    return result;
+}
+
+unittest
+{
+    Code block;
+    block.info = "name=test1 name=test2";
+    assert(getBlockNames(block) == ["test1", "test2"]);
+}
+
+unittest
+{
+    Code block;
+    block.info = "name=test1 name=test1";
+    assert(getBlockNames(block) == ["test1"]);
+}
+
+unittest
+{
+    Code block;
+    block.info = "single global";
+    assert(getBlockNames(block) == ["main"]);
+}
+
+unittest
+{
+    Code block;
+    block.info = "name=test1 name=test2";
+    assert(filterBlockNames(getBlockNames(block), ["test1"]) == ["test1"]);
+    assert(filterBlockNames(getBlockNames(block), ["test2"]) == ["test2"]);
+    assert(filterBlockNames(getBlockNames(block), ["test3"]).length == 0);
+}
+
+unittest
+{
+    Code block;
+    block.info = "name=test1 name=test2";
+    assert(isFilteredBlock(block, ["test2"]));
+    assert(!isFilteredBlock(block, ["test3"]));
 }
 
 enum BlockType


### PR DESCRIPTION
This pull request adds support for assigning multiple `name` attributes to a single code block, allowing a block to be included in multiple named groups. The documentation has been updated, and the codebase now properly parses, filters, and executes blocks with multiple names. The changes also ensure block execution order is preserved and include new tests to verify the functionality.

**Multiple name attribute support:**

* Added parsing logic in `source/commands/main.d` to extract multiple names from a code block's `info` string, ensuring duplicates are removed and defaulting to `"main"` if no names are present.
* Updated block filtering and execution logic to handle multiple names, including the new `filterBlockNames` function and changes to block ordering and evaluation. (F304c3d1L108R108, [[1]](diffhunk://#diff-e57696a31af404725319da6b96354cb510012f2085490de636230c3003a79fb3L116-R148) [[2]](diffhunk://#diff-e57696a31af404725319da6b96354cb510012f2085490de636230c3003a79fb3L102-L104) [[3]](diffhunk://#diff-e57696a31af404725319da6b96354cb510012f2085490de636230c3003a79fb3R94)

**Documentation and examples:**

* Added English and Japanese documentation in `README.md` and `README.ja.md` describing how to use multiple `name` attributes and how filtering works. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R109-R135) [[2]](diffhunk://#diff-b3fc642ee9795d9cb415501fb1ca7858d4222eb6f32ae8dc26ae29b3f1934336R111-R137)
* Introduced a new example file `examples/test-multiple-name.md` demonstrating usage and expected output for blocks with multiple names and filters.

**Testing:**

* Added several unit tests in `source/commands/main.d` to verify correct parsing, filtering, and block inclusion for multiple names.