### PR TITLE
Support execution of shell and bash code blocks

### DIFF
--- a/.github/workflows/test-md.yml
+++ b/.github/workflows/test-md.yml
@@ -41,6 +41,7 @@ jobs:
         dub run md --compiler=$DC -- examples/test-compiler.md --compiler=$DC
         dub run md --compiler=$DC -- examples/test-build.md --build=release --compiler=$DC
         dub run md --compiler=$DC -- examples/test-compiler.md --build=release --compiler=$DC
+        dub run md --compiler=$DC -- examples/test-shell.md
 
     - name: 'Run filter tests'
       run: dub run md -- examples/test-filter.md --filter test1
@@ -48,3 +49,9 @@ jobs:
       run: dub run md -- examples/test-filter-multiple.md --filter test1 --filter test2
     - name: 'Run no matching filter tests'
       run: dub run md -- examples/test-filter-multiple.md --filter test100
+    - name: 'Run shell filters tests'
+      run: |
+        dub run md -- examples/test-shell.md --filter sh_test
+        dub run md -- examples/test-shell.md --filter bash_test
+    - name: 'Oracle log format tests'
+      run: bash examples/oracle-log-format.sh

--- a/README.ja.md
+++ b/README.ja.md
@@ -25,7 +25,7 @@ dub run md -- --help
 
 ## 機能概要
 
-言語に `d` または `D` と指定されているコードブロックが実行されます。
+言語に `d`, `D`, `sh`, `bash` と指定されているコードブロックが実行されます。
 
 ### ブロックの結合
 
@@ -135,6 +135,44 @@ writeln("multi-name test1");
 writeln("multi-name test2");
 ```
 
+### シェルブロック
+
+`sh` と `bash` のブロックも、Dと同じ `name` と `--filter` のルールで実行されます。
+`name` 省略時は `main` 扱いで、1つのブロックに複数の `name` も指定できます。
+
+~~~
+```sh name=shell_sample
+```
+~~~
+
+```
+dub run md -- README.md --filter=shell_sample
+dub run md -- README.md --filter=bash_sample
+```
+
+```sh name=shell_sample
+shared_shell="from-sh"
+echo "sh:${shared_shell}"
+```
+
+```bash name=shell_sample name=bash_sample
+shared_bash="from-bash"
+```
+
+```bash name=bash_sample
+parts=("A" "B")
+echo "bash:${shared_bash}:${parts[1]}"
+```
+
+実行方式:
+1. `sh` ブロックは `sh -eu <temp_script_path>` で実行
+2. `bash` ブロックは `bash -eu -o pipefail <temp_script_path>` で実行
+3. 実行時のカレントディレクトリは `md` コマンドを起動したディレクトリ
+4. 終了コードが0以外なら失敗扱い
+5. `--build`, `--compiler`, `--arch`, `--dependency`, `--dubsdl` はD実行にのみ適用
+6. `--buildOnly` 指定時はシェルスクリプト実行をスキップ
+7. `--show-lang` を指定すると begin/end ラベルを `<language>:<block-name>` 形式で表示（既定は従来形式）
+
 ### 独立実行
 
 1つのコードブロックを他のブロックと結合せず、独立して実行させるためには `single` という属性を付与します。
@@ -219,7 +257,14 @@ void main()
 
 ### 実行時の仕組み
 
-tempディレクトリに `.md` ディレクトリを作り、dubのシングルファイル形式のソースを生成、 `dub run --single md_xxx.md` といったコマンドで実行します。
+tempディレクトリに `.md` ディレクトリを作り、実行単位ごとの一時ファイルを生成して実行します。
+
+言語ごとの実行方式:
+1. D: dubのシングルファイル形式ソースを生成し、 `dub run --single md_xxx.d` で実行（`--buildOnly` 時は `dub build --single ...`）
+2. sh: スクリプトを生成し、 `sh -eu md_xxx.sh` で実行
+3. bash: スクリプトを生成し、 `bash -eu -o pipefail md_xxx.sh` で実行
+
+名前付きブロックは `language + name` 単位で結合され、 `--filter` 指定時は対象nameのみ実行されます。
 
 また、既定のパッケージ参照を実現するため、ソースの先頭に以下のようなコメントを自動的に付与します。
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ dub run md -- --help
 
 ## Features
 
-The code block whose language is specified as `d` or `D` will be executed.
+The code block whose language is specified as `d`, `D`, `sh`, or `bash` will be executed.
 
 ### Combine blocks
 
@@ -133,6 +133,44 @@ writeln("multi-name test1");
 writeln("multi-name test2");
 ```
 
+### Shell blocks
+
+`sh` and `bash` blocks are executed with the same `name` and `--filter` rules as D blocks.
+The default name is `main`, and a single block can have multiple names.
+
+~~~
+```sh name=shell_sample
+```
+~~~
+
+```
+dub run md -- README.md --filter=shell_sample
+dub run md -- README.md --filter=bash_sample
+```
+
+```sh name=shell_sample
+shared_shell="from-sh"
+echo "sh:${shared_shell}"
+```
+
+```bash name=shell_sample name=bash_sample
+shared_bash="from-bash"
+```
+
+```bash name=bash_sample
+parts=("A" "B")
+echo "bash:${shared_bash}:${parts[1]}"
+```
+
+Execution details:
+1. `sh` blocks run as `sh -eu <temp_script_path>`
+2. `bash` blocks run as `bash -eu -o pipefail <temp_script_path>`
+3. Scripts are executed from the current working directory where `md` is launched
+4. Non-zero exit code is treated as an error
+5. `--build`, `--compiler`, `--arch`, `--dependency`, and `--dubsdl` apply only to D execution
+6. `--buildOnly` skips shell script execution
+7. `--show-lang` prints language-aware begin/end labels as `<language>:<block-name>` (default keeps the original label format)
+
 
 
 ### Scoped block
@@ -218,7 +256,14 @@ void main()
 
 ### How it works
 
-Create a `.md` directory in the temp directory, generate the source in dub single file format, and run it with a command like `dub run --single md_xxx.md`.
+Create a `.md` directory in the temp directory and generate temporary files for each execution unit.
+
+Execution model by language:
+1. D: generate a dub single-file source and run it with `dub run --single md_xxx.d` (or `dub build --single ...` with `--buildOnly`)
+2. sh: generate a script file and run `sh -eu md_xxx.sh`
+3. bash: generate a script file and run `bash -eu -o pipefail md_xxx.sh`
+
+Named blocks are combined by `language + name` before execution, and `--filter` narrows the target names.
 
 It also automatically adds the following comment to the beginning of the source to achieve default package references.
 

--- a/examples/oracle-log-format.sh
+++ b/examples/oracle-log-format.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+run_md() {
+  HOME=/tmp dub run -q -- "$@"
+}
+
+assert_has() {
+  local output="$1"
+  local pattern="$2"
+  local message="$3"
+  if ! grep -Eq "$pattern" <<<"$output"; then
+    echo "[oracle] FAIL: $message" >&2
+    echo "[oracle] missing pattern: $pattern" >&2
+    exit 1
+  fi
+}
+
+assert_not_has() {
+  local output="$1"
+  local pattern="$2"
+  local message="$3"
+  if grep -Eq "$pattern" <<<"$output"; then
+    echo "[oracle] FAIL: $message" >&2
+    echo "[oracle] unexpected pattern: $pattern" >&2
+    exit 1
+  fi
+}
+
+echo "[oracle] check default named log format"
+out_default_shell="$(run_md examples/test-shell.md 2>&1)"
+assert_has "$out_default_shell" '^begin: sh_test$' 'default log must keep name-only format for sh_test'
+assert_has "$out_default_shell" '^begin: bash_test$' 'default log must keep name-only format for bash_test'
+assert_not_has "$out_default_shell" '^begin: (d|sh|bash):' 'default log must not include language prefix for named blocks'
+
+echo "[oracle] check --show-lang named log format"
+out_lang_shell="$(run_md examples/test-shell.md --show-lang 2>&1)"
+assert_has "$out_lang_shell" '^begin: sh:sh_test$' '--show-lang must include sh:sh_test'
+assert_has "$out_lang_shell" '^begin: sh:bash_test$' '--show-lang must include sh:bash_test'
+assert_has "$out_lang_shell" '^begin: bash:sh_test$' '--show-lang must include bash:sh_test'
+assert_has "$out_lang_shell" '^begin: bash:bash_test$' '--show-lang must include bash:bash_test'
+
+echo "[oracle] check default single/global log format"
+out_default_readme="$(run_md README.md 2>&1)"
+assert_has "$out_default_readme" '^begin single: 0$' 'default single log must keep numeric label'
+assert_has "$out_default_readme" '^begin global :0$' 'default global log must keep numeric label (0)'
+assert_has "$out_default_readme" '^begin global :1$' 'default global log must keep numeric label (1)'
+assert_not_has "$out_default_readme" '^begin single: d:0$' 'default single log must not include language prefix'
+assert_not_has "$out_default_readme" '^begin global :d:0$' 'default global log must not include language prefix'
+
+echo "[oracle] check --show-lang single/global log format"
+out_lang_readme="$(run_md README.md --show-lang 2>&1)"
+assert_has "$out_lang_readme" '^begin: d:main$' '--show-lang must include d prefix for named D block'
+assert_has "$out_lang_readme" '^begin: sh:shell_sample$' '--show-lang must include sh prefix for named shell block'
+assert_has "$out_lang_readme" '^begin single: d:0$' '--show-lang must include d prefix for single block'
+assert_has "$out_lang_readme" '^begin global :d:0$' '--show-lang must include d prefix for global block (0)'
+assert_has "$out_lang_readme" '^begin global :d:1$' '--show-lang must include d prefix for global block (1)'
+
+echo "[oracle] PASS"

--- a/examples/test-shell.md
+++ b/examples/test-shell.md
@@ -1,0 +1,47 @@
+__command__
+
+```
+dub run -- examples/test-shell.md
+dub run -- examples/test-shell.md --filter sh_test
+dub run -- examples/test-shell.md --filter bash_test
+```
+
+__test code__
+
+```sh name=sh_test name=bash_test
+shared_sh="multi-name"
+```
+
+```sh name=sh_test
+echo "sh:${shared_sh}"
+```
+
+```bash name=sh_test name=bash_test
+shared_bash="multi-name"
+```
+
+```bash name=bash_test
+parts=("A" "B")
+echo "bash:${shared_bash}:${parts[1]}"
+```
+
+### expected output
+
+no filter:
+
+```
+sh:multi-name
+bash:multi-name:B
+```
+
+filter sh_test:
+
+```
+sh:multi-name
+```
+
+filter bash_test:
+
+```
+bash:multi-name:B
+```

--- a/source/commands/main.d
+++ b/source/commands/main.d
@@ -27,6 +27,10 @@ struct DefaultCommand
         @(ArgConfig.parseAsFlag)
         bool verbose;
 
+        @ArgNamed("show-lang", "Print language prefix for begin/end logs")
+        @(ArgConfig.parseAsFlag)
+        bool showLanguage;
+
         @ArgNamed("dependency|d", "Adds a DUB dependency into the D source. May be either in format `name` (version \"*\") or `name@version` to download an exact version or version range.")
         @(ArgConfig.aggregate | ArgConfig.optional)
         string[] dubDependencies;
@@ -90,44 +94,47 @@ struct DefaultCommand
         string filepath = !file.isNull ? file.get() : "README.md";
         auto result = parseMarkdown(filepath);
 
-        Appender!(string)[string] blocks;
-        string[] orderedNames;
+        Appender!(string)[string] namedBlocks;
+        NamedExecutionUnit[] orderedUnits;
         string[] singleBlocks;
         string[] globalBlocks;
         foreach (block; result.blocks)
         {
-            if (block.lang == "d" || block.lang == "D")
+            if (isDisabledBlock(block))
+                continue;
+
+            auto language = normalizeLanguage(block.lang);
+            if (!isSupportedLanguage(language))
+                continue;
+
+            if (isDLanguage(language) && isSingleBlock(block))
             {
-                if (isDisabledBlock(block))
-                    continue;
-                if (isSingleBlock(block))
-                {
-                    singleBlocks ~= block.code[].to!string();
-                    continue;
-                }
-                if (isGlobalBlock(block))
-                {
-                    globalBlocks ~= block.code[].to!string();
-                    continue;
-                }
+                singleBlocks ~= block.code[].to!string();
+                continue;
+            }
+            if (isDLanguage(language) && isGlobalBlock(block))
+            {
+                globalBlocks ~= block.code[].to!string();
+                continue;
+            }
 
-                auto names = getBlockNames(block);
-                if (filters.length > 0)
-                {
-                    names = filterBlockNames(names, filters);
-                    if (names.length == 0)
-                        continue;
-                }
+            auto names = getBlockNames(block);
+            if (filters.length > 0)
+            {
+                names = filterBlockNames(names, filters);
+                if (names.length == 0)
+                    continue;
+            }
 
-                foreach (name; names)
+            foreach (name; names)
+            {
+                const key = makeUnitKey(language, name);
+                if (!(key in namedBlocks))
                 {
-                    if (!(name in blocks))
-                    {
-                        blocks[name] = appender!string;
-                        orderedNames ~= name;
-                    }
-                    blocks[name].put(block.code[]);
+                    namedBlocks[key] = appender!string;
+                    orderedUnits ~= NamedExecutionUnit(language, name);
                 }
+                namedBlocks[key].put(block.code[]);
             }
         }
 
@@ -136,42 +143,54 @@ struct DefaultCommand
 
         size_t totalCount;
         size_t errorCount;
-        foreach (name; orderedNames)
+        foreach (unit; orderedUnits)
         {
             totalCount++;
+            auto namedLabel = formatNamedLogLabel(unit.language, unit.name, showLanguage);
             if (!quiet)
-                writeln("begin: ", name);
+                writeln("begin: ", namedLabel);
             scope (exit)
                 if (!quiet)
-                    writeln("end: ", name);
+                    writeln("end: ", namedLabel);
 
-            const status = evaluate(blocks[name].data, dubInstructions, BlockType.Single, runSettings, verbose, buildOnly);
+            const source = namedBlocks[makeUnitKey(unit.language, unit.name)].data;
+            int status;
+            if (isDLanguage(unit.language))
+            {
+                status = evaluateD(source, dubInstructions, BlockType.Single, runSettings, verbose, buildOnly);
+            }
+            else
+            {
+                status = evaluateShell(source, unit.language, verbose, buildOnly);
+            }
             errorCount += status != 0;
         }
 
         foreach (i, source; singleBlocks)
         {
             totalCount++;
+            auto singleLabel = formatDIndexedLogLabel(i, showLanguage);
             if (!quiet)
-                writeln("begin single: ", i);
+                writeln("begin single: ", singleLabel);
             scope (exit)
                 if (!quiet)
-                    writeln("end single: ", i);
+                    writeln("end single: ", singleLabel);
 
-            const status = evaluate(source, dubInstructions, BlockType.Single, runSettings, verbose, buildOnly);
+            const status = evaluateD(source, dubInstructions, BlockType.Single, runSettings, verbose, buildOnly);
             errorCount += status != 0;
         }
 
         foreach (i, source; globalBlocks)
         {
             totalCount++;
+            auto globalLabel = formatDIndexedLogLabel(i, showLanguage);
             if (!quiet)
-                writeln("begin global :", i);
+                writeln("begin global :", globalLabel);
             scope (exit)
                 if (!quiet)
-                    writeln("end global :", i);
+                    writeln("end global :", globalLabel);
 
-            const status = evaluate(source, dubInstructions, BlockType.Global, runSettings, verbose, buildOnly);
+            const status = evaluateD(source, dubInstructions, BlockType.Global, runSettings, verbose, buildOnly);
             errorCount += status != 0;
         }
 
@@ -234,6 +253,44 @@ struct Code
     const(char)[] lang;
     const(char)[] info;
     Array!char code;
+}
+
+struct NamedExecutionUnit
+{
+    string language;
+    string name;
+}
+
+string makeUnitKey(string language, string name)
+{
+    return language ~ "\x1f" ~ name;
+}
+
+string normalizeLanguage(const(char)[] language)
+{
+    if (language.length == 0)
+        return "";
+    return language.to!string.toLower();
+}
+
+bool isDLanguage(string language)
+{
+    return language == "d";
+}
+
+bool isSupportedLanguage(string language)
+{
+    return isDLanguage(language) || language == "sh" || language == "bash";
+}
+
+string formatNamedLogLabel(string language, string name, bool showLanguage)
+{
+    return showLanguage ? language ~ ":" ~ name : name;
+}
+
+string formatDIndexedLogLabel(size_t index, bool showLanguage)
+{
+    return showLanguage ? "d:" ~ to!string(index) : to!string(index);
 }
 
 struct CodeAggregator
@@ -416,6 +473,29 @@ unittest
     assert(!isFilteredBlock(block, ["test3"]));
 }
 
+unittest
+{
+    assert(isSupportedLanguage("d"));
+    assert(isSupportedLanguage(normalizeLanguage("D")));
+    assert(isSupportedLanguage("sh"));
+    assert(isSupportedLanguage("bash"));
+    assert(!isSupportedLanguage("python"));
+    assert(normalizeLanguage("BASH") == "bash");
+}
+
+unittest
+{
+    assert(makeUnitKey("d", "main") == "d\x1fmain");
+}
+
+unittest
+{
+    assert(formatNamedLogLabel("sh", "test", false) == "test");
+    assert(formatNamedLogLabel("sh", "test", true) == "sh:test");
+    assert(formatDIndexedLogLabel(0, false) == "0");
+    assert(formatDIndexedLogLabel(1, true) == "d:1");
+}
+
 enum BlockType
 {
     Single,
@@ -450,15 +530,15 @@ struct DubRunSettings
     }
 }
 
-int evaluate(string source, string[] dubInstructions, BlockType type, DubRunSettings settings, bool verbose, bool skipRun)
+int evaluateD(string source, string[] dubInstructions, BlockType type, DubRunSettings settings, bool verbose, bool skipRun)
 {
     import std.conv : text, to;
     import std.digest : toHexString, LetterCase;
     import std.digest.murmurhash : MurmurHash3;
-    import std.file : chdir, mkdirRecurse, remove, tempDir, write;
+    import std.file : mkdirRecurse, tempDir;
     import std.path : buildNormalizedPath;
     import std.process : spawnProcess, wait;
-    import std.stdio : stderr, stdin, stdout;
+    import std.stdio : stdin, stdout;
 
     auto workDir = buildNormalizedPath(tempDir(), ".md");
     mkdirRecurse(workDir);
@@ -510,6 +590,62 @@ int evaluate(string source, string[] dubInstructions, BlockType type, DubRunSett
         writeln("dub args: ", args);
 
     auto result = spawnProcess(args, stdin, stdout);
+    return wait(result);
+}
+
+int evaluateShell(string source, string shellKind, bool verbose, bool skipRun)
+{
+    import std.conv : text;
+    import std.digest : toHexString, LetterCase;
+    import std.digest.murmurhash : MurmurHash3;
+    import std.file : mkdirRecurse, tempDir;
+    import std.path : buildNormalizedPath;
+    import std.process : spawnProcess, wait;
+    import std.stdio : stdin, stdout, stderr;
+
+    auto workDir = buildNormalizedPath(tempDir(), ".md");
+    mkdirRecurse(workDir);
+
+    MurmurHash3!128 hasher;
+    hasher.start();
+    hasher.put(source.representation);
+    hasher.put(shellKind.representation);
+    auto hash = hasher.finish();
+
+    auto scriptName = text("md_", hash.toHexString!(LetterCase.lower)(), ".sh");
+    auto scriptPath = buildNormalizedPath(workDir, scriptName);
+    if (verbose)
+    {
+        writeln("scriptPath: ", scriptPath);
+    }
+
+    {
+        auto sourceFile = File(scriptPath, "w");
+        sourceFile.write(source);
+        sourceFile.flush();
+    }
+
+    if (skipRun)
+    {
+        if (verbose)
+            writeln("skip run for ", shellKind, " script by --buildOnly");
+        return 0;
+    }
+
+    string[] args;
+    if (shellKind == "bash")
+    {
+        args = ["bash", "-eu", "-o", "pipefail", scriptPath];
+    }
+    else
+    {
+        args = ["sh", "-eu", scriptPath];
+    }
+
+    if (verbose)
+        writeln("shell args: ", args);
+
+    auto result = spawnProcess(args, stdin, stdout, stderr);
     return wait(result);
 }
 


### PR DESCRIPTION
This pull request adds support for executing shell code blocks (`sh` and `bash`) in markdown files, alongside existing support for D code blocks. It updates the documentation to describe the new behavior, introduces comprehensive tests for shell block execution and logging, and refactors the main execution logic to handle multiple languages in a unified way. Additionally, it adds a `--show-lang` flag to control log label formats.

**Shell and Bash Block Execution:**

- Added support for executing code blocks marked as `sh` or `bash` in markdown files, using appropriate shell interpreters (`sh -eu` or `bash -eu -o pipefail`). Shell blocks follow the same `name` and `--filter` rules as D blocks, and can be combined or filtered by name. (`[[1]](diffhunk://#diff-e57696a31af404725319da6b96354cb510012f2085490de636230c3003a79fb3R258-R295)`, `[[2]](diffhunk://#diff-e57696a31af404725319da6b96354cb510012f2085490de636230c3003a79fb3L93-R115)`, `[[3]](diffhunk://#diff-e57696a31af404725319da6b96354cb510012f2085490de636230c3003a79fb3L124-R137)`, `[[4]](diffhunk://#diff-e57696a31af404725319da6b96354cb510012f2085490de636230c3003a79fb3L139-R193)`, `[[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L28-R28)`, `[[6]](diffhunk://#diff-b3fc642ee9795d9cb415501fb1ca7858d4222eb6f32ae8dc26ae29b3f1934336L28-R28)`, `[[7]](diffhunk://#diff-91638bb116ccb1d0b2b9332fb2b2239245a8168b1b3c3e743a7f3d66f46b0ad4R1-R47)`)

**Logging and CLI Improvements:**

- Introduced a `--show-lang` command-line flag to print language-prefixed begin/end log labels (e.g., `sh:myblock`), with updated logic to format log labels for named, single, and global blocks accordingly. (`[[1]](diffhunk://#diff-e57696a31af404725319da6b96354cb510012f2085490de636230c3003a79fb3R30-R33)`, `[[2]](diffhunk://#diff-e57696a31af404725319da6b96354cb510012f2085490de636230c3003a79fb3R258-R295)`, `[[3]](diffhunk://#diff-e57696a31af404725319da6b96354cb510012f2085490de636230c3003a79fb3L139-R193)`, `[[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R136-R173)`, `[[5]](diffhunk://#diff-b3fc642ee9795d9cb415501fb1ca7858d4222eb6f32ae8dc26ae29b3f1934336R138-R175)`)
- Updated documentation in both `README.md` and `README.ja.md` to describe the new shell block features, execution details, and log formatting options. (`[[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R136-R173)`, `[[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L221-R266)`, `[[3]](diffhunk://#diff-b3fc642ee9795d9cb415501fb1ca7858d4222eb6f32ae8dc26ae29b3f1934336R138-R175)`, `[[4]](diffhunk://#diff-b3fc642ee9795d9cb415501fb1ca7858d4222eb6f32ae8dc26ae29b3f1934336L222-R267)`)

**Testing Enhancements:**

- Added new tests in the workflow (`test-md.yml`) to cover shell block execution and log formats, including a new `examples/test-shell.md` file and an oracle script (`examples/oracle-log-format.sh`) to verify log label correctness. (`[[1]](diffhunk://#diff-e300eb0115bf85709ebeeda1f0a51db735ed6753a26aa47e8521d02989d8ae2bR44-R57)`, `[[2]](diffhunk://#diff-766171401720aabe301abfbf9390ef64beb2340e5cba46493a1fa420178a592bR1-R62)`, `[[3]](diffhunk://#diff-91638bb116ccb1d0b2b9332fb2b2239245a8168b1b3c3e743a7f3d66f46b0ad4R1-R47)`)

**Refactoring and Code Structure:**

- Refactored the main execution logic to generalize handling of named execution units across multiple languages, including key normalization, language checks, and block aggregation. (`[[1]](diffhunk://#diff-e57696a31af404725319da6b96354cb510012f2085490de636230c3003a79fb3L93-R115)`, `[[2]](diffhunk://#diff-e57696a31af404725319da6b96354cb510012f2085490de636230c3003a79fb3L124-R137)`, `[[3]](diffhunk://#diff-e57696a31af404725319da6b96354cb510012f2085490de636230c3003a79fb3R258-R295)`)
- Added unittests for new helper functions and language support logic. (`[source/commands/main.dR476-R498](diffhunk://#diff-e57696a31af404725319da6b96354cb510012f2085490de636230c3003a79fb3R476-R498)`)

**Shell Evaluation Implementation:**

- Implemented `evaluateShell` to execute shell scripts in a temp directory, with proper error handling and verbose output options. (`[source/commands/main.dR596-R651](diffhunk://#diff-e57696a31af404725319da6b96354cb510012f2085490de636230c3003a79fb3R596-R651)`)

These changes collectively enable robust, filterable execution and logging of shell code blocks in markdown documentation, with improved test coverage and user-facing documentation.